### PR TITLE
Use --all option to import all and display help if no args provided.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Add *all* Pinboard bookmarks to Buku:
 
 .. code-block::
 
-    pinku
+    pinku -a
 
 Add your 10 most recent Pinboard bookmarks to Buku:
 


### PR DESCRIPTION
Currently, running `pinku` automatically imports the entirety of your Pinboard library into `buku`.  This behavior can be dangerous (though relatively low stakes) and would require user to do clean up in `buku` if run accidentally. 

This PR introduces the `--all` (or `-a`) option, so that the user must explicitly declare that the entirety of their Pinboard library should be imported.